### PR TITLE
Guard tag generator against empty lines

### DIFF
--- a/tag_generator.py
+++ b/tag_generator.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+'''
+tag_generator.py
+
+Copyright 2017 Long Qian
+Contact: lqian8@jhu.edu
+
+This script creates tags for your Jekyll blog hosted by Github page.
+No plugins required.
+'''
+
+import glob
+import os
+
+post_dir = '_posts/'
+proj_dir = '_projects/'      
+tag_dir = 'tag/'
+
+postfiles = glob.glob(post_dir + '*md')
+projfiles = glob.glob(proj_dir + '*md')
+filenames = postfiles + projfiles
+
+total_tags = []
+for filename in filenames:
+    print(filename)
+    f = open(filename, 'r', encoding='utf8')
+    crawl = False
+    for line in f:
+        if crawl:
+            current_tags = line.strip().split()
+            if current_tags and current_tags[0] == 'tags:':
+                total_tags.extend(current_tags[1:])
+                crawl = False
+                break
+        if line.strip() == '---':
+            if not crawl:
+                crawl = True
+            else:
+                crawl = False
+                break
+    f.close()
+total_tags = set(total_tags)
+
+old_tags = glob.glob(tag_dir + '*.md')
+for tag in old_tags:
+    os.remove(tag)
+    
+if not os.path.exists(tag_dir):
+    os.makedirs(tag_dir)
+
+for tag in total_tags:
+    tag_filename = tag_dir + tag + '.md'
+    f = open(tag_filename, 'a')
+    write_str = '---\nlayout: tagpage\ntitle: \"Tag: ' + tag + '\"\ntag: ' + tag + '\nrobots: noindex\nsitemap: false\n---\n'
+    f.write(write_str)
+    f.close()
+print("Tags generated, count", total_tags.__len__())


### PR DESCRIPTION
## Summary
- prevent tag_generator.py from crashing when a blank line precedes the tags section

## Testing
- `python3 tag_generator.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5e20966fc832fa5181a1e83249e42